### PR TITLE
Updates for OS X usage

### DIFF
--- a/buildosx/InstallOSX/ocpn_draw_pi.pkgproj.in
+++ b/buildosx/InstallOSX/ocpn_draw_pi.pkgproj.in
@@ -74,183 +74,17 @@
 												</dict>
 												<dict>
 													<key>CHILDREN</key>
-													<array>
-														<dict>
-															<key>CHILDREN</key>
-															<array>
-																<dict>
-																	<key>CHILDREN</key>
-																	<array/>
-																	<key>GID</key>
-																	<integer>80</integer>
-																	<key>PATH</key>
-																	<string>Resources/de.lproj/opencpn-${PACKAGE_NAME}.mo</string>
-																	<key>PATH_TYPE</key>
-																	<integer>3</integer>
-																	<key>PERMISSIONS</key>
-																	<integer>420</integer>
-																	<key>TYPE</key>
-																	<integer>3</integer>
-																	<key>UID</key>
-																	<integer>0</integer>
-																</dict>
-															</array>
-															<key>GID</key>
-															<integer>80</integer>
-															<key>PATH</key>
-															<string>de.lproj</string>
-															<key>PATH_TYPE</key>
-															<integer>0</integer>
-															<key>PERMISSIONS</key>
-															<integer>509</integer>
-															<key>TYPE</key>
-															<integer>2</integer>
-															<key>UID</key>
-															<integer>0</integer>
-														</dict>
-														<dict>
-															<key>CHILDREN</key>
-															<array>
-																<dict>
-																	<key>CHILDREN</key>
-																	<array/>
-																	<key>GID</key>
-																	<integer>80</integer>
-																	<key>PATH</key>
-																	<string>Resources/es.lproj/opencpn-${PACKAGE_NAME}.mo</string>
-																	<key>PATH_TYPE</key>
-																	<integer>3</integer>
-																	<key>PERMISSIONS</key>
-																	<integer>420</integer>
-																	<key>TYPE</key>
-																	<integer>3</integer>
-																	<key>UID</key>
-																	<integer>0</integer>
-																</dict>
-															</array>
-															<key>GID</key>
-															<integer>80</integer>
-															<key>PATH</key>
-															<string>es.lproj</string>
-															<key>PATH_TYPE</key>
-															<integer>0</integer>
-															<key>PERMISSIONS</key>
-															<integer>509</integer>
-															<key>TYPE</key>
-															<integer>2</integer>
-															<key>UID</key>
-															<integer>0</integer>
-														</dict>
-														<dict>
-															<key>CHILDREN</key>
-															<array>
-																<dict>
-																	<key>CHILDREN</key>
-																	<array/>
-																	<key>GID</key>
-																	<integer>80</integer>
-																	<key>PATH</key>
-																	<string>Resources/et.lproj/opencpn-${PACKAGE_NAME}.mo</string>
-																	<key>PATH_TYPE</key>
-																	<integer>3</integer>
-																	<key>PERMISSIONS</key>
-																	<integer>420</integer>
-																	<key>TYPE</key>
-																	<integer>3</integer>
-																	<key>UID</key>
-																	<integer>0</integer>
-																</dict>
-															</array>
-															<key>GID</key>
-															<integer>80</integer>
-															<key>PATH</key>
-															<string>et.lproj</string>
-															<key>PATH_TYPE</key>
-															<integer>0</integer>
-															<key>PERMISSIONS</key>
-															<integer>509</integer>
-															<key>TYPE</key>
-															<integer>2</integer>
-															<key>UID</key>
-															<integer>0</integer>
-														</dict>
-														<dict>
-															<key>CHILDREN</key>
-															<array>
-																<dict>
-																	<key>CHILDREN</key>
-																	<array/>
-																	<key>GID</key>
-																	<integer>80</integer>
-																	<key>PATH</key>
-																	<string>Resources/fr.lproj/opencpn-${PACKAGE_NAME}.mo</string>
-																	<key>PATH_TYPE</key>
-																	<integer>3</integer>
-																	<key>PERMISSIONS</key>
-																	<integer>420</integer>
-																	<key>TYPE</key>
-																	<integer>3</integer>
-																	<key>UID</key>
-																	<integer>0</integer>
-																</dict>
-															</array>
-															<key>GID</key>
-															<integer>80</integer>
-															<key>PATH</key>
-															<string>fr.lproj</string>
-															<key>PATH_TYPE</key>
-															<integer>0</integer>
-															<key>PERMISSIONS</key>
-															<integer>509</integer>
-															<key>TYPE</key>
-															<integer>2</integer>
-															<key>UID</key>
-															<integer>0</integer>
-														</dict>
-														<dict>
-															<key>CHILDREN</key>
-															<array>
-																<dict>
-																	<key>CHILDREN</key>
-																	<array/>
-																	<key>GID</key>
-																	<integer>80</integer>
-																	<key>PATH</key>
-																	<string>Resources/pl.lproj/opencpn-${PACKAGE_NAME}.mo</string>
-																	<key>PATH_TYPE</key>
-																	<integer>3</integer>
-																	<key>PERMISSIONS</key>
-																	<integer>420</integer>
-																	<key>TYPE</key>
-																	<integer>3</integer>
-																	<key>UID</key>
-																	<integer>0</integer>
-																</dict>
-															</array>
-															<key>GID</key>
-															<integer>80</integer>
-															<key>PATH</key>
-															<string>pl.lproj</string>
-															<key>PATH_TYPE</key>
-															<integer>0</integer>
-															<key>PERMISSIONS</key>
-															<integer>509</integer>
-															<key>TYPE</key>
-															<integer>2</integer>
-															<key>UID</key>
-															<integer>0</integer>
-														</dict>
-													</array>
+													<array/>
 													<key>GID</key>
 													<integer>80</integer>
 													<key>PATH</key>
 													<string>Resources</string>
 													<key>PATH_TYPE</key>
-													<integer>0</integer>
+													<integer>3</integer>
 													<key>PERMISSIONS</key>
-													<integer>509</integer>
+													<integer>493</integer>
 													<key>TYPE</key>
-													<integer>2</integer>
+													<integer>3</integer>
 													<key>UID</key>
 													<integer>0</integer>
 												</dict>
@@ -1214,7 +1048,7 @@
 							<key>LANGUAGE</key>
 							<string>Czech</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Please install OpenCPN version 3.3.1606 (or later) in Applications folder.</string>
+							<string>Please install OpenCPN version 4.1.602 (or later) in Applications folder.</string>
 							<key>VALUE</key>
 							<string>OpenCPN not found.</string>
 						</dict>
@@ -1222,7 +1056,7 @@
 							<key>LANGUAGE</key>
 							<string>Dutch</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Please install OpenCPN version 3.3.1606 (or later) in Applications folder.</string>
+							<string>Please install OpenCPN version 4.1.602 (or later) in Applications folder.</string>
 							<key>VALUE</key>
 							<string>OpenCPN not found.</string>
 						</dict>
@@ -1230,7 +1064,7 @@
 							<key>LANGUAGE</key>
 							<string>English</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Please install OpenCPN version 3.3.1606 (or later) in Applications folder.</string>
+							<string>Please install OpenCPN version 4.1.602 (or later) in Applications folder.</string>
 							<key>VALUE</key>
 							<string>OpenCPN not found.</string>
 						</dict>
@@ -1238,7 +1072,7 @@
 							<key>LANGUAGE</key>
 							<string>French</string>
 							<key>SECONDARY_VALUE</key>
-							<string>S'il vous plait, installez la version 3.3.1606 (or later) dans le dossier des applications.</string>
+							<string>S'il vous plait, installez la version 4.1.602 (or later) dans le dossier des applications.</string>
 							<key>VALUE</key>
 							<string>OpenCPN n'existe pas</string>
 						</dict>
@@ -1246,7 +1080,7 @@
 							<key>LANGUAGE</key>
 							<string>German</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Bitte erst OpenCPN Version3.3.1606 (or later) im Programme Ordner installieren.</string>
+							<string>Bitte erst OpenCPN Version 4.1.602 (or later) im Programme Ordner installieren.</string>
 							<key>VALUE</key>
 							<string>OpenCPN nicht gefunden.
 </string>
@@ -1255,7 +1089,7 @@
 							<key>LANGUAGE</key>
 							<string>Italian</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Please install first OpenCPN version 3.3.1606 (or later) in Applications folder.</string>
+							<string>Please install first OpenCPN version 4.1.602 (or later) in Applications folder.</string>
 							<key>VALUE</key>
 							<string>OpenCPN not found.</string>
 						</dict>
@@ -1263,7 +1097,7 @@
 							<key>LANGUAGE</key>
 							<string>Spanish</string>
 							<key>SECONDARY_VALUE</key>
-							<string>Instale por favor primero OpenCPN versión 3.3.1606 (or later) en la carpeta de Aplicaciones</string>
+							<string>Instale por favor primero OpenCPN versión 4.1.602 (or later) en la carpeta de Aplicaciones</string>
 							<key>VALUE</key>
 							<string>OpenCPN no encontrado</string>
 						</dict>
@@ -1297,7 +1131,7 @@
 							<key>SECONDARY_VALUE</key>
 							<string></string>
 							<key>VALUE</key>
-							<string>OpenCPN Version undetermined.  Assuming 3.3.1606 or later.</string>
+							<string>OpenCPN Version undetermined.  Assuming 4.1.602 or later.</string>
 						</dict>
 					</array>
 					<key>NAME</key>
@@ -1531,7 +1365,7 @@ if (chk_flag) {
 // is it the right version of OpenCPN?
   ocpn_data = system.files.bundleAtPath('/Applications/OpenCPN.app');
 ocpn_vers = ocpn_data.CFBundleShortVersionString;
-chk_flag = (ocpn_vers &gt;= '3.3.1606'); }
+chk_flag = (ocpn_vers &gt;= '4.1.602'); }
 } catch (e) {
 // an exception just occurred
  return (false)

--- a/src/ODPropertiesImpl.cpp
+++ b/src/ODPropertiesImpl.cpp
@@ -73,7 +73,7 @@ void ODPropertiesImpl::OnDrawPropertiesOKClick( wxCommandEvent& event )
 {
     SaveChanges(); // write changes to globals and update config
     Show( false );
-
+	EndModal(wxID_OK);
     SetClientSize(m_defaultClientSize);
 
     event.Skip();
@@ -82,6 +82,7 @@ void ODPropertiesImpl::OnDrawPropertiesOKClick( wxCommandEvent& event )
 void ODPropertiesImpl::OnDrawPropertiesCancelClick( wxCommandEvent& event )
 {
     Show( false );
+	EndModal(wxID_CANCEL);
     SetClientSize(m_defaultClientSize);
 
     event.Skip();

--- a/src/PathProp.cpp
+++ b/src/PathProp.cpp
@@ -195,7 +195,7 @@ PathProp::PathProp( wxWindow* parent, wxWindowID id, const wxString& caption, co
     m_pEnroutePoint = NULL;
     m_bStartNow = false;
 #ifdef __WXOSX__
-    wstyle |= wxSTAY_ON_TOP;
+    style |= wxSTAY_ON_TOP;
 #endif
 
     SetExtraStyle( GetExtraStyle() | wxWS_EX_BLOCK_EVENTS );


### PR DESCRIPTION
Updated ODPreopertiesImpl.cpp as the window closes but control is not given back to parent in OS X.
Updated PathProp for typo wstyle iso style.
Updated pkgproj to add all languages files into the package and check for O4.1 to be able to install the plugin.