### PR TITLE
Make toolbar button toggle draw manager dialog popup

### DIFF
--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -865,10 +865,12 @@ void ocpn_draw_pi::OnToolbarToolDownCallback(int id)
             g_pPathManagerDialog->Centre();
             g_pPathManagerDialog->Raise();
 #endif
-            nConfig_State = 0;
             //SetToolbarItemState( m_config_button_id, false );
             
         } else {
+            if( NULL != g_pPathManagerDialog )
+	        g_pPathManagerDialog->Hide();
+
             nConfig_State = 0;
             //SetToolbarItemState( m_config_button_id, false );
         }


### PR DESCRIPTION
Unlike most other toolbar button, the draw manager button does not
hide the popup when it's shown and the button is clicked.