### PR TITLE
GetOrFindMaskColour is slow, only call it if we can't shortcut test

### DIFF
--- a/ocpnsrc/ocpndc.cpp
+++ b/ocpnsrc/ocpndc.cpp
@@ -963,22 +963,22 @@ void ocpnDC::DrawBitmap( const wxBitmap &bitmap, wxCoord x, wxCoord y, bool usem
             unsigned char *d = image.GetData();
             unsigned char *a = image.GetAlpha();
 
-            unsigned char mr, mg, mb;
-            if( !image.GetOrFindMaskColour( &mr, &mg, &mb ) && !a ){
-                printf("trying to use mask to draw a bitmap without alpha or mask\n" );
-            }
-
 #ifdef __WXOSX__            
             if(image.HasMask())
                 a=0;
 #endif
+            unsigned char mr, mg, mb;
+            if( !a && !image.GetOrFindMaskColour( &mr, &mg, &mb ) ){
+                printf("trying to use mask to draw a bitmap without alpha or mask\n" );
+            }
+
             
             unsigned char *e = new unsigned char[4 * w * h];
             if(e && d){
                 for( int y = 0; y < h; y++ )
                     for( int x = 0; x < w; x++ ) {
                         unsigned char r, g, b;
-                        int off = ( y * image.GetWidth() + x );
+                        int off = ( y * w + x );
                         r = d[off * 3 + 0];
                         g = d[off * 3 + 1];
                         b = d[off * 3 + 2];

--- a/src/ODdc.cpp
+++ b/src/ODdc.cpp
@@ -1288,7 +1288,7 @@ void ODDC::DrawBitmap( const wxBitmap &bitmap, wxCoord x, wxCoord y, bool usemas
             unsigned char *a = image.GetAlpha();
 
             unsigned char mr, mg, mb;
-            if( !image.GetOrFindMaskColour( &mr, &mg, &mb ) && !a ) printf(
+            if( !a && !image.GetOrFindMaskColour( &mr, &mg, &mb ) ) printf(
                     "trying to use mask to draw a bitmap without alpha or mask\n" );
 
             unsigned char *e = new unsigned char[4 * w * h];
@@ -1296,7 +1296,7 @@ void ODDC::DrawBitmap( const wxBitmap &bitmap, wxCoord x, wxCoord y, bool usemas
                 for( int y = 0; y < h; y++ )
                     for( int x = 0; x < w; x++ ) {
                         unsigned char r, g, b;
-                        int off = ( y * image.GetWidth() + x );
+                        int off = ( y * w + x );
                         r = d[off * 3 + 0];
                         g = d[off * 3 + 1];
                         b = d[off * 3 + 2];

--- a/src/PointMan.cpp
+++ b/src/PointMan.cpp
@@ -530,7 +530,8 @@ unsigned int PointMan::GetIconTexture( const wxBitmap *pbm, int &glw, int &glh )
         unsigned char *a = image.GetAlpha();
             
         unsigned char mr, mg, mb;
-        image.GetOrFindMaskColour( &mr, &mg, &mb );
+        if (!a)
+            image.GetOrFindMaskColour( &mr, &mg, &mb );
     
         unsigned char *e = new unsigned char[4 * w * h];
         if(d && e){


### PR DESCRIPTION
Hi,

GetOrFindMaskColour is rather slow (it shows up in perf top) and if there's an alpha channel , most if not all of the time there's one, its output is not used.

Only call it if we are going to use it.

Regards
Didier
