### PR TITLE
fixes for 5af06d47e color modes

### DIFF
--- a/include/ocpn_draw_pi.h
+++ b/include/ocpn_draw_pi.h
@@ -322,6 +322,7 @@ public:
     wxString GetLongDescription();
     void UpdateAuiStatus(void);
 //    void SetColorScheme(PI_ColorScheme cs);
+    PI_ColorScheme GetColorScheme() { return m_global_color_scheme;};
     void GetOriginalColors();
     void SetOriginalColors();
     void LateInit(void);

--- a/src/ODNavObjectChanges.cpp
+++ b/src/ODNavObjectChanges.cpp
@@ -63,6 +63,7 @@ extern bool             g_bInclusionBoundaryPoint;
 extern int              g_navobjbackups;
 extern int              g_iGZMaxNum;
 
+extern ocpn_draw_pi     *g_ocpn_draw_pi;
 
 ODNavObjectChanges::ODNavObjectChanges() : pugi::xml_document()
 {
@@ -1207,6 +1208,17 @@ ODPoint * ODNavObjectChanges::GPXLoadODPoint1( pugi::xml_node &opt_node,
         pOP->m_IconName = SymString;
         pOP->SetName( NameString );
     }
+    pOP->SetMarkDescription( DescString );
+    pOP->m_sTypeString = TypeString;
+    pOP->SetODPointArrivalRadius( ArrivalRadius );
+    pOP->SetODPointRangeRingsNumber( l_iODPointRangeRingsNumber );
+    pOP->SetODPointRangeRingsStep( l_fODPointRangeRingsStep );
+    pOP->SetODPointRangeRingsStepUnits( l_pODPointRangeRingsStepUnits );
+    pOP->SetShowODPointRangeRings( l_bODPointRangeRingsVisible );
+    pOP->SetODPointRangeRingsColour( l_wxcODPointRangeRingsColour );
+    pOP->SetODPointRangeRingWidth( l_iODPointRangeRingWidth );
+    pOP->SetODPointRangeRingStyle( l_iODPointRangeRingStyle );
+
     if( pTP && TypeString == _T("Text Point") ) {
         pTP->SetPointText( TextString );
         pTP->m_iTextPosition = l_iTextPosition;
@@ -1225,23 +1237,17 @@ ODPoint * ODNavObjectChanges::GPXLoadODPoint1( pugi::xml_node &opt_node,
         pTP->m_iBackgroundTransparency = l_iBackgroundTransparency;
         pTP->m_natural_scale = l_natural_scale;
         pTP->m_iDisplayTextWhen = l_display_text_when;
+        pTP -> CreateColourSchemes();
+        pTP->SetColourScheme(g_ocpn_draw_pi->GetColorScheme());
     } else if ( pBP && TypeString == _T("Boundary Point") ) {
         pBP -> m_bExclusionBoundaryPoint = l_bExclusionBoundaryPoint;
         pBP -> m_bInclusionBoundaryPoint = l_bInclusionBoundaryPoint;
         pBP -> m_iInclusionBoundaryPointSize = l_iInclusionBoundaryPointSize;
         pBP -> m_uiBoundaryPointFillTransparency = l_uiBoundaryPointFillTransparency;
+        pBP -> CreateColourSchemes();
+        pBP->SetColourScheme(g_ocpn_draw_pi->GetColorScheme());
     }
     
-    pOP->SetMarkDescription( DescString );
-    pOP->m_sTypeString = TypeString;
-    pOP->SetODPointArrivalRadius( ArrivalRadius );
-    pOP->SetODPointRangeRingsNumber( l_iODPointRangeRingsNumber );
-    pOP->SetODPointRangeRingsStep( l_fODPointRangeRingsStep );
-    pOP->SetODPointRangeRingsStepUnits( l_pODPointRangeRingsStepUnits );
-    pOP->SetShowODPointRangeRings( l_bODPointRangeRingsVisible );
-    pOP->SetODPointRangeRingsColour( l_wxcODPointRangeRingsColour );
-    pOP->SetODPointRangeRingWidth( l_iODPointRangeRingWidth );
-    pOP->SetODPointRangeRingStyle( l_iODPointRangeRingStyle );
 
     if( b_propvizname )
         pOP->m_bShowName = bviz_name;
@@ -1588,7 +1594,10 @@ ODPath *ODNavObjectChanges::GPXLoadPath1( pugi::xml_node &odpoint_node  , bool b
         delete pTentPath->m_HyperlinkList;                    // created in RoutePoint ctor
         pTentPath->m_HyperlinkList = linklist;
     }
+    pTentPath->CreateColourSchemes();
+    pTentPath->SetColourScheme(g_ocpn_draw_pi->GetColorScheme());
     pTentPath->SetActiveColours();
+
     pTentPath->UpdateSegmentDistances();
     pTentPath->m_bIsBeingCreated = false;
     

--- a/src/ODPathPropertiesDialogImpl.cpp
+++ b/src/ODPathPropertiesDialogImpl.cpp
@@ -662,6 +662,8 @@ bool ODPathPropertiesDialogImpl::SaveChanges( void )
         
         m_pPath->m_wxcActiveLineColour = m_colourPickerLineColour->GetColour();
         m_pPath->CreateColourSchemes();
+        m_pPath->SetColourScheme(g_ocpn_draw_pi->GetColorScheme());
+
         m_pPath->SetActiveColours();
         m_pPath->m_style = ::StyleValues[m_choiceLineStyle->GetSelection()];
         m_pPath->m_width = ::WidthValues[m_choiceLineWidth->GetSelection()];

--- a/src/ODPointPropertiesImpl.cpp
+++ b/src/ODPointPropertiesImpl.cpp
@@ -307,8 +307,7 @@ void ODPointPropertiesImpl::SaveChanges()
 //        m_pODPoint->m_fODPointRangeRingsStep = m_RangeRingSteps;
         m_pODPoint->m_iODPointRangeRingsStepUnits = m_choiceDistanceUnitsString->GetSelection();
         m_pODPoint->m_wxcODPointRangeRingsColour = m_colourPickerRangeRingsColour->GetColour();
-        m_pODPoint->CreateColourSchemes();
-
+     
         m_pODPoint->SetName( m_textName->GetValue() );
         m_pODPoint->SetODPointArrivalRadius( m_textCtrlODPointArrivalRadius->GetValue() );
         m_pODPoint->SetShowODPointRangeRings( m_checkBoxShowODPointRangeRings->GetValue() );
@@ -354,6 +353,9 @@ void ODPointPropertiesImpl::SaveChanges()
             
             
         }
+        m_pODPoint->CreateColourSchemes();
+        m_pODPoint->SetColourScheme(g_ocpn_draw_pi->GetColorScheme());
+
         m_pODPoint->SetVisible( m_checkBoxVisible->GetValue() );
         m_pODPoint->SetNameShown( m_checkBoxShowName->GetValue() );
         if(m_pODPoint->m_sTypeString == wxT("Guard Zone Point")) {

--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -377,6 +377,7 @@ ocpn_draw_pi::ocpn_draw_pi(void *ppimgr)
     g_pLayerDir->Append(*l_pDir);
     g_pLayerDir->Append( wxT("Layers") );
     appendOSDirSlash( g_pLayerDir );
+    m_global_color_scheme = PI_GLOBAL_COLOR_SCHEME_DAY;
     
     m_pODicons = new ODicons();
 }


### PR DESCRIPTION
Hi,

5af06d47e 'Updated to allow RGB, Day, Dusk and Night modes to modify the display of OD objects' commit has introduced some regressions, try to fix them.

There's still weird stuff going on with point visibility and toolbar icons (GZ dialog box corrupts toolbar and GPS indicator).

Regards
Didier
