### PR TITLE
Disable fix

### DIFF
--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -650,8 +650,8 @@ int ocpn_draw_pi::Init(void)
     g_pBoundaryPropDialog = NULL;
     g_pEBLPropDialog = NULL;
     g_pDRPropDialog = NULL;
-    g_pPILPropDialog = NULL;
     g_pGZPropDialog = NULL;
+    g_pPILPropDialog = NULL;
     g_PILIndexLinePropDialog = NULL;
     
     g_pODConfig->LoadNavObjects();
@@ -701,10 +701,33 @@ bool ocpn_draw_pi::DeInit(void)
     g_ODEventHandler = NULL;
     if( g_pODRolloverWin ) g_pODRolloverWin->Destroy();
     g_pODRolloverWin = NULL;
-    if( g_pODPointPropDialog ) delete g_pODPointPropDialog;
-    g_pODPointPropDialog = NULL;
 
     g_pODPathPropDialog = NULL;
+
+    if( g_pODPointPropDialog ) g_pODPointPropDialog->Destroy();
+    g_pODPointPropDialog = NULL;
+
+    if ( g_pBoundaryPropDialog ) g_pBoundaryPropDialog->Destroy();
+    g_pBoundaryPropDialog = NULL;
+
+    if ( g_pEBLPropDialog ) g_pEBLPropDialog->Destroy();
+    g_pEBLPropDialog = NULL;
+
+    if ( g_pDRPropDialog ) g_pDRPropDialog->Destroy();
+    g_pDRPropDialog = NULL;
+
+    if ( g_pGZPropDialog ) g_pGZPropDialog->Destroy();
+    g_pGZPropDialog = NULL;
+
+    if ( g_pPILPropDialog )  g_pPILPropDialog->Destroy();
+    g_pPILPropDialog = NULL;
+
+    if ( g_PILIndexLinePropDialog )  g_PILIndexLinePropDialog->Destroy();
+    g_PILIndexLinePropDialog = NULL;
+
+    if ( g_pPathManagerDialog )  g_pPathManagerDialog->Destroy();
+    g_pPathManagerDialog = NULL;
+
     if( g_pODToolbar ) g_pODToolbar->Destroy();
     g_pODToolbar = NULL;
     if( g_pODJSON ) delete g_pODJSON;
@@ -725,6 +748,16 @@ bool ocpn_draw_pi::DeInit(void)
         g_pODConfig->UpdateNavObj();
         SaveConfig();
     }
+
+    delete g_pGZMan;
+    delete g_pBoundaryMan;
+    delete g_pPathMan;
+#if 0
+    // XXX FIXME core dump
+    // path first/last point is inserted twice in the list
+    // but points have only one manager pointer so double freed.
+    delete g_pODPointMan;
+#endif
     shutdown(false);
     return true;
 }

--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -651,6 +651,7 @@ int ocpn_draw_pi::Init(void)
     g_pEBLPropDialog = NULL;
     g_pDRPropDialog = NULL;
     g_pPILPropDialog = NULL;
+    g_pGZPropDialog = NULL;
     g_PILIndexLinePropDialog = NULL;
     
     g_pODConfig->LoadNavObjects();
@@ -702,7 +703,7 @@ bool ocpn_draw_pi::DeInit(void)
     g_pODRolloverWin = NULL;
     if( g_pODPointPropDialog ) delete g_pODPointPropDialog;
     g_pODPointPropDialog = NULL;
-    if( g_pODPathPropDialog ) delete g_pODPathPropDialog;
+
     g_pODPathPropDialog = NULL;
     if( g_pODToolbar ) g_pODToolbar->Destroy();
     g_pODToolbar = NULL;


### PR DESCRIPTION
Hi,
first patch : you can kill opencpn by creating a GZ open GZ prop. dialog then disable and re-enable draw plugin.

second commit : destroy (close and delete) all draw plugins dialog boxes when disabling it. You can disable the plugins with dialogs on screen it's  puzzling if they stay open (they half work).

It closes a leak too but I guess few will compulsively disable/enable draw plugin.
On the other there's an issue with g_pODPointMan logic because first point is also stored as last point and it breaks deleting g_pODPointMan or recovering data from ODnavobj.xml.changes.
  
Regards
Didier