### PR TITLE
remove setlocale logic

### DIFF
--- a/include/GZProp.h
+++ b/include/GZProp.h
@@ -70,7 +70,6 @@ class GZProp : public ODPathPropertiesDialogImpl
         double  m_dODGZSecondLengthValidator;
         bool    m_bLockGZAngle;
         bool    m_bLockGZLength;
-        bool    m_bSetLocale;
         bool    m_bLockUpdate;
         
 };

--- a/include/ODUtils.h
+++ b/include/ODUtils.h
@@ -36,8 +36,6 @@
  double         FNday( int y, int m, int d, int h );
  double         FNrange( double x );
  double         getLMT( double ut, double lon );
- void           SetGlobalLocale( void );
- void           ResetGlobalLocale( void );
  bool           pointInPolygon(int polyCorners, double *polyX, double *polyY, double x, double y);
  bool           GetLineIntersection(double p0_x, double p0_y, double p1_x, double p1_y, double p2_x, double p2_y, double p3_x, double p3_y, double *i_x, double *i_y);
  int            ArcSectorPoints( wxPoint *&points, wxCoord xc, wxCoord yc, wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2, wxCoord x3, wxCoord y3, wxCoord x4, wxCoord y4, bool bHighQuality );

--- a/src/EBLProp.cpp
+++ b/src/EBLProp.cpp
@@ -101,8 +101,6 @@ EBLProp::~EBLProp()
 
 bool EBLProp::UpdateProperties( EBL *pInEBL )
 {
-    SetGlobalLocale();
-    
     wxString s;
 
     m_checkBoxEBLFixedEndPosition->SetValue( pInEBL->m_bFixedEndPosition );
@@ -316,7 +314,6 @@ void EBLProp::OnClose( wxCloseEvent& event )
     m_bLockEBLAngle = false;
     ODPathPropertiesDialogImpl::OnClose(event);
     
-    ResetGlobalLocale();
 }
 
 void EBLProp::OnCancel( wxCommandEvent& event )
@@ -325,7 +322,6 @@ void EBLProp::OnCancel( wxCommandEvent& event )
     m_bLockEBLAngle = false;
     ODPathPropertiesDialogImpl::OnCancel(event);
 
-    ResetGlobalLocale();
 }
 
 

--- a/src/GZProp.cpp
+++ b/src/GZProp.cpp
@@ -111,8 +111,6 @@ GZProp::~GZProp()
 
 bool GZProp::UpdateProperties( GZ *pInGZ )
 {
-    SetGlobalLocale();
-    
     wxString s;
 
     m_colourPickerFillColour->SetColour( m_pGZ->m_wxcActiveFillColour );
@@ -306,8 +304,6 @@ void GZProp::OnClose( wxCloseEvent& event )
     m_bLockGZLength = false;
     m_bLockGZAngle = false;
     ODPathPropertiesDialogImpl::OnClose(event);
-    
-    ResetGlobalLocale();
 }
 
 void GZProp::OnCancel( wxCommandEvent& event )
@@ -315,8 +311,6 @@ void GZProp::OnCancel( wxCommandEvent& event )
     m_bLockGZLength = false;
     m_bLockGZAngle = false;
     ODPathPropertiesDialogImpl::OnCancel(event);
-
-    ResetGlobalLocale();
 }
 
 

--- a/src/ODDRDialogImpl.cpp
+++ b/src/ODDRDialogImpl.cpp
@@ -77,7 +77,6 @@ extern ODPointPropertiesImpl        *g_pODPointPropDialog;
 
 ODDRDialogImpl::ODDRDialogImpl( wxWindow* parent ) : ODDRDialogDef( parent )
 {
-    SetGlobalLocale();
 #if wxCHECK_VERSION(3,0,0) && !defined(__WXMSW__)
     wxFloatingPointValidator<double> dSOGVal(3, &m_dSOGValidator, wxNUM_VAL_DEFAULT);
     wxFloatingPointValidator<double> dLengthVal(3, &m_dLengthValidator, wxNUM_VAL_DEFAULT);
@@ -123,14 +122,10 @@ ODDRDialogImpl::ODDRDialogImpl( wxWindow* parent ) : ODDRDialogDef( parent )
     m_pDR = NULL;
     
     this->Layout();
-    
-    ResetGlobalLocale();
 }
 
 void ODDRDialogImpl::SetupDialog()
 {
-    SetGlobalLocale();
-    
     wxString s;
     if(g_bShowMag && !wxIsNaN(g_dVar)) s = _("Course over Ground (M)");
     else s = _("Course over Ground (T)");
@@ -167,8 +162,6 @@ void ODDRDialogImpl::SetupDialog()
 
 void ODDRDialogImpl::UpdateDialog( DR * dr)
 {
-    SetGlobalLocale();
-    
     m_pDR = dr;
     wxString s;
     if(g_bShowMag && !wxIsNaN(g_dVar)) s = _("Course over Ground (M)");
@@ -350,7 +343,6 @@ void ODDRDialogImpl::OnOK( wxCommandEvent& event )
     EndModal(wxID_CANCEL);
 #endif
     
-    ResetGlobalLocale();
     m_pDR = NULL;
 }
 
@@ -361,7 +353,6 @@ void ODDRDialogImpl::OnCancel( wxCommandEvent& event )
     EndModal(wxID_CANCEL);
 #endif
     
-    ResetGlobalLocale();
     m_pDR = NULL;
     event.Skip();
 }

--- a/src/ODEventHandler.cpp
+++ b/src/ODEventHandler.cpp
@@ -253,9 +253,6 @@ void ODEventHandler::OnRolloverPopupTimerEvent( wxTimerEvent& event )
     return;
     #endif
 
-#ifndef __WXMSW__
-    wxString *l_locale = NULL;
-#endif
     
     bool b_need_refresh = false;
     
@@ -266,17 +263,6 @@ void ODEventHandler::OnRolloverPopupTimerEvent( wxTimerEvent& event )
         SelectableItemList SelList = g_pODSelect->FindSelectionList( g_ocpn_draw_pi->m_cursor_lat, g_ocpn_draw_pi->m_cursor_lon, SELTYPE_PATHSEGMENT | SELTYPE_PIL );
         
         wxSelectableItemListNode *node = SelList.GetFirst();
-        if(node) {
-#ifndef __WXMSW__
-			l_locale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)        
-            wxSetlocale(LC_NUMERIC, "");
-#else
-            setlocale(LC_NUMERIC, "");
-#endif
-#endif
-            
-        }
         while( node ) {
             SelectItem *pFindSel = node->GetData();
             ODPath *pp = (ODPath *) pFindSel->m_pData3;        //candidate
@@ -543,17 +529,6 @@ void ODEventHandler::OnRolloverPopupTimerEvent( wxTimerEvent& event )
     if( b_need_refresh )
         RequestRefresh( g_ocpn_draw_pi->m_parent_window );
 
-#ifndef __WXMSW__
-    if(l_locale) {
-#if wxCHECK_VERSION(3,0,0)        
-        wxSetlocale(LC_NUMERIC, l_locale->ToAscii());
-#else
-        setlocale(LC_NUMERIC, l_locale->ToAscii());
-#endif
-        delete l_locale;
-    }
-#endif
-    
 }
 
 void ODEventHandler::PopupMenuHandler(wxCommandEvent& event ) 

--- a/src/ODNavObjectChanges.cpp
+++ b/src/ODNavObjectChanges.cpp
@@ -162,15 +162,6 @@ bool ODNavObjectChanges::GPXCreateODPoint( pugi::xml_node node, ODPoint *pop, un
     pugi::xml_node child;
     pugi::xml_attribute attr;
     
-#ifndef __WXMSW__
-    wxString *l_locale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, "C");
-#else
-    setlocale(LC_NUMERIC, "C");
-#endif
-#endif
-    
     s.Printf(_T("%.9f"), pop->m_lat);
     node.append_attribute("lat") = s.mb_str();
     s.Printf(_T("%.9f"), pop->m_lon);
@@ -367,15 +358,6 @@ bool ODNavObjectChanges::GPXCreateODPoint( pugi::xml_node node, ODPoint *pop, un
         }
     }
 
-#ifndef __WXMSW__
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, l_locale->ToAscii());
-#else
-    setlocale(LC_NUMERIC, l_locale->ToAscii());
-#endif
-    delete l_locale;
-#endif
-    
     return true;
 }
 
@@ -387,16 +369,6 @@ bool ODNavObjectChanges::GPXCreatePath( pugi::xml_node node, ODPath *pInPath )
     DR  *pDR = NULL;
     GZ  *pGZ = NULL;
     PIL *pPIL = NULL;
-    
-#ifndef __WXMSW__
-    wxString *l_locale;
-    l_locale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, "C");
-#else
-    setlocale(LC_NUMERIC, "C");
-#endif
-#endif
     
     if(pInPath->m_sTypeString == wxT("Boundary")) {
         pBoundary = (Boundary *)pInPath;
@@ -660,15 +632,6 @@ bool ODNavObjectChanges::GPXCreatePath( pugi::xml_node node, ODPath *pInPath )
             
         node2 = node2->GetNext();
     }
-    
-#ifndef __WXMSW__
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, l_locale->ToAscii());
-#else
-    setlocale(LC_NUMERIC, l_locale->ToAscii());
-#endif
-    delete l_locale;
-#endif
     
     return true;
 }
@@ -935,14 +898,6 @@ ODPoint * ODNavObjectChanges::GPXLoadODPoint1( pugi::xml_node &opt_node,
                             bool b_InPath
                             )
 {
-#ifndef __WXMSW__
-    wxString *l_locale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, "C");
-#else
-    setlocale(LC_NUMERIC, "C");
-#endif
-#endif
     
     bool bviz = false;
     bool bviz_name = false;
@@ -1274,14 +1229,6 @@ ODPoint * ODNavObjectChanges::GPXLoadODPoint1( pugi::xml_node &opt_node,
         pOP->m_HyperlinkList = linklist;
     }
 
-#ifndef __WXMSW__
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, l_locale->ToAscii());
-#else
-    setlocale(LC_NUMERIC, l_locale->ToAscii());
-#endif
-    delete l_locale;
-#endif    
     return ( pOP );
 }
 
@@ -1295,15 +1242,6 @@ ODPath *ODNavObjectChanges::GPXLoadPath1( pugi::xml_node &odpoint_node  , bool b
         return 0;
     }
         
-#ifndef __WXMSW__
-    wxString *l_locale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, "C");
-#else
-    setlocale(LC_NUMERIC, "C");
-#endif
-#endif
-    
     wxString PathName;
     wxString DescString;
     bool b_propviz = false;
@@ -1586,15 +1524,6 @@ ODPath *ODNavObjectChanges::GPXLoadPath1( pugi::xml_node &odpoint_node  , bool b
     pTentPath->SetActiveColours();
     pTentPath->UpdateSegmentDistances();
     pTentPath->m_bIsBeingCreated = false;
-    
-#ifndef __WXMSW__
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, l_locale->ToAscii());
-#else
-    setlocale(LC_NUMERIC, l_locale->ToAscii());
-#endif
-    delete l_locale;
-#endif
     
     return pTentPath;
 }

--- a/src/ODPathPropertiesDialogImpl.cpp
+++ b/src/ODPathPropertiesDialogImpl.cpp
@@ -177,8 +177,6 @@ void ODPathPropertiesDialogImpl::OnCancel( wxCommandEvent& event )
     Hide();
     RequestRefresh( GetOCPNCanvasWindow() );
     
-    ResetGlobalLocale();
-    
     event.Skip();
 }
 
@@ -381,8 +379,6 @@ bool ODPathPropertiesDialogImpl::UpdateProperties( ODPath *pInPath )
     if( NULL == pInPath ) return false;
     ::wxBeginBusyCursor();
    
-    SetGlobalLocale();
-    
     if(pInPath->m_sTypeString == wxT("Boundary")) {
         pBoundary = (Boundary *)pInPath;
         pPath = pBoundary;
@@ -541,8 +537,6 @@ bool ODPathPropertiesDialogImpl::UpdateProperties( ODPath *pInPath )
 
 bool ODPathPropertiesDialogImpl::UpdateProperties( void )
 {
-    SetGlobalLocale();
-    
     ::wxBeginBusyCursor();
     
     //  Iterate on Path Points
@@ -669,8 +663,6 @@ bool ODPathPropertiesDialogImpl::SaveChanges( void )
         g_pODConfig->UpdatePath( m_pPath );
         //g_ocpn_draw_pi->SaveConfig();
     }
-    
-    ResetGlobalLocale();
     
     return true;
 }

--- a/src/ODPropertiesDialogImpl.cpp
+++ b/src/ODPropertiesDialogImpl.cpp
@@ -405,7 +405,6 @@ void ODPropertiesDialogImpl::OnDrawPropertiesOKClick( wxCommandEvent& event )
 #endif
     SetClientSize(m_defaultClientSize);
 
-    ResetGlobalLocale();
     event.Skip();
 }
 
@@ -417,7 +416,6 @@ void ODPropertiesDialogImpl::OnDrawPropertiesCancelClick( wxCommandEvent& event 
 #endif
     SetClientSize(m_defaultClientSize);
 
-    ResetGlobalLocale();
     event.Skip();
 }
 
@@ -661,7 +659,6 @@ void ODPropertiesDialogImpl::SetDialogSize( void )
 
 void ODPropertiesDialogImpl::UpdateProperties( void )
 {
-    SetGlobalLocale();
     SetTableCellBackgroundColours();
     m_textCtrlODPointArrivalRadius->SetValue( wxString::Format( _T("%.3f"), g_n_arrival_circle_radius ) );
     

--- a/src/ODUtils.cpp
+++ b/src/ODUtils.cpp
@@ -33,9 +33,6 @@
 #include "ocpn_plugin.h"
 #include "ocpn_draw_pi.h"
 
-extern int      g_iLocaleDepth;
-extern wxString *g_ODlocale;
-
 /*!
  * Helper stuff for calculating Path
  */
@@ -252,40 +249,6 @@ double getLMT( double ut, double lon )
         return ( t - 24. );
     else
         return ( t + 24. );
-}
-
-// International helper functions
-void SetGlobalLocale( void )
-{
-#ifndef __WXMSW__
-    if(g_iLocaleDepth == 0) { 
-        g_ODlocale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)        
-        wxSetlocale(LC_NUMERIC, "");
-#else
-        setlocale(LC_NUMERIC, "");
-#endif
-    }
-    g_iLocaleDepth++;
-#endif
-}
-
-void ResetGlobalLocale( void )
-{
-#ifndef __WXMSW__
-    g_iLocaleDepth--;
-    if(g_iLocaleDepth < 0) 
-        g_iLocaleDepth = 0;
-    if(g_iLocaleDepth == 0 && g_ODlocale) {
-#if wxCHECK_VERSION(3,0,0)        
-        wxSetlocale(LC_NUMERIC, g_ODlocale->ToAscii());
-#else
-        setlocale(LC_NUMERIC, g_ODlocale->ToAscii());
-#endif
-        delete g_ODlocale;
-        g_ODlocale = NULL;
-    } 
-#endif
 }
 
 // Returns 1 if the lines intersect, otherwise 0. In addition, if the lines 

--- a/src/PILProp.cpp
+++ b/src/PILProp.cpp
@@ -98,8 +98,6 @@ bool PILProp::UpdateProperties( PIL *pInPIL )
 
     ::wxBeginBusyCursor();
 
-    SetGlobalLocale();
-
     wxString s;
 
     m_textCtrlName->SetValue( pInPIL->m_PathNameString );
@@ -248,8 +246,6 @@ void PILProp::OnClose( wxCloseEvent& event )
     m_bLockPILLength = false;
     m_bLockPILAngle = false;
     ODPathPropertiesDialogImpl::OnClose(event);
-    
-    ResetGlobalLocale();
 }
 
 void PILProp::OnCancel( wxCommandEvent& event )
@@ -257,8 +253,6 @@ void PILProp::OnCancel( wxCommandEvent& event )
     m_bLockPILLength = false;
     m_bLockPILAngle = false;
     ODPathPropertiesDialogImpl::OnCancel(event);
-
-    ResetGlobalLocale();
 }
 
 

--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -292,9 +292,6 @@ ODPoint       *pAnchorWatchPoint2;
 
 IDX_entry       *gpIDX;
 
-wxString        *g_ODlocale;
-int             g_iLocaleDepth;
-
 int             g_click_stop;
 bool            g_bConfirmObjectDelete;
 
@@ -430,8 +427,6 @@ int ocpn_draw_pi::Init(void)
     g_iGZMaxNum = 0;
     m_chart_scale = 0.;
     g_pfFix.valid = false;
-    g_iLocaleDepth = 0;
-    g_ODlocale = NULL;
     
     // Drawing modes from toolbar
     m_Mode = 0;
@@ -734,10 +729,6 @@ bool ocpn_draw_pi::DeInit(void)
     g_pODJSON = NULL;
     if( g_pODAPI ) delete g_pODAPI;
     g_pODAPI = NULL;
-    
-    while(g_iLocaleDepth) {
-        ResetGlobalLocale();
-    }
     
     if( m_config_button_id ) RemovePlugInTool(m_config_button_id);
     m_config_button_id = 0;
@@ -1200,15 +1191,6 @@ void ocpn_draw_pi::OnToolbarToolUpCallback(int id)
 }
 void ocpn_draw_pi::SaveConfig()
 {
-#ifndef __WXMSW__
-    wxString *l_locale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)  && !defined(_WXMSW_)       
-    wxSetlocale(LC_NUMERIC, "C");
-#else
-    setlocale(LC_NUMERIC, "C");
-#endif
-#endif
-    
     wxFileConfig *pConf = m_pODConfig;
     
     if(pConf)
@@ -1351,26 +1333,10 @@ void ocpn_draw_pi::SaveConfig()
         
     }
     
-#ifndef __WXMSW__
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, l_locale->ToAscii());
-#else
-    setlocale(LC_NUMERIC, l_locale->ToAscii());
-#endif
-    delete l_locale;
-#endif
 }
 
 void ocpn_draw_pi::LoadConfig()
 {
-#ifndef __WXMSW__
-    wxString *l_locale = new wxString(wxSetlocale(LC_NUMERIC, NULL));
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, "C");
-#else
-    setlocale(LC_NUMERIC, "C");
-#endif
-#endif
     
     wxFileConfig *pConf = (wxFileConfig *)m_pODConfig;
     
@@ -1609,14 +1575,6 @@ void ocpn_draw_pi::LoadConfig()
         pConf->Read( wxS( "DefaultTextPointDisplayTextWhen" ), &g_iTextPointDisplayTextWhen, ID_TEXTPOINT_DISPLAY_TEXT_SHOW_ALWAYS );
     }
 
-#ifndef __WXMSW__
-#if wxCHECK_VERSION(3,0,0)        
-    wxSetlocale(LC_NUMERIC, l_locale->ToAscii());
-#else
-    setlocale(LC_NUMERIC, l_locale->ToAscii());
-#endif
-    delete l_locale;
-#endif
 }
 
 void ocpn_draw_pi::SetPluginMessage(wxString &message_id, wxString &message_body)


### PR DESCRIPTION
Hi,
setlocale usage can corrupt GPS reading.

How to reproduce:
when receiving gps data, open draw dialog box on a linux system with locale using comma as decimal separator (aka continental Europe) , GPS positions are now truncated to degrees minutes.

Anyway every other opencpn dialogs are using '.' for decimal separator even for locale with LC_NUMERIC ','.

Regards
Didier
