### PR TITLE
MESA really care about GLMinSymbolLineWidth

### DIFF
--- a/src/ODdc.cpp
+++ b/src/ODdc.cpp
@@ -1457,7 +1457,7 @@ bool ODDC::ConfigurePen()
 #ifdef ocpnUSE_GL
     if(c != wxNullColour)
         glColor4ub( c.Red(), c.Green(), c.Blue(), c.Alpha() );
-    glLineWidth( width );
+    glLineWidth(wxMax(g_GLMinSymbolLineWidth, width) );
 #endif    
     return true;
 }

--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -380,7 +380,14 @@ ocpn_draw_pi::ocpn_draw_pi(void *ppimgr)
     g_pLayerDir->Append(*l_pDir);
     g_pLayerDir->Append( wxT("Layers") );
     appendOSDirSlash( g_pLayerDir );
-    
+#if defined(__WXMSW__) || defined(__WXOSX__)
+    // Windows wants 0? cf. 1b982628
+    g_GLMinSymbolLineWidth = 0.f;
+#else
+    // XXX FIXME get it from driver
+    g_GLMinSymbolLineWidth = 1.0f;
+#endif
+
     m_pODicons = new ODicons();
 }
 


### PR DESCRIPTION
hi,

For testing (it should use actual value) but on linux with Mesa and I get (only with boundary point) if line is zero width:  
![capture du 2017-11-18 17 51 26](https://user-images.githubusercontent.com/12138026/33339566-d8e6629c-d479-11e7-9666-0658902d349d.png)

Regards
Didier
