### PR TITLE
Speedup

### DIFF
--- a/src/ODNavObjectChanges.cpp
+++ b/src/ODNavObjectChanges.cpp
@@ -1609,8 +1609,8 @@ ODPoint *ODNavObjectChanges::ODPointExists( const wxString& name, double lat, do
 
 //        if( pr->m_bIsInLayer ) return NULL;
 
-        if( name == pr->GetName() ) {
-            if( fabs( lat - pr->m_lat ) < 1.e-6 && fabs( lon - pr->m_lon ) < 1.e-6 ) {
+        if( fabs( lat - pr->m_lat ) < 1.e-6 && fabs( lon - pr->m_lon ) < 1.e-6 ) {
+            if( name == pr->GetName() ) {
                 pret = pr;
                 break;
             }

--- a/src/ODSelect.cpp
+++ b/src/ODSelect.cpp
@@ -121,20 +121,15 @@ bool ODSelect::DeleteAllSelectablePathSegments( ODPath *pr )
 
     while( node ) {
         pFindSel = node->GetData();
+        wxSelectableItemListNode *next = node->GetNext();
         if( pFindSel->m_seltype == SELTYPE_PATHSEGMENT || pFindSel->m_seltype == SELTYPE_PIL ) {
 
             if( (ODPath *) pFindSel->m_pData3 == pr ) {
                 delete pFindSel;
                 pSelectList->DeleteNode( node );   //delete node;
-
-                node = pSelectList->GetFirst();     // reset the top node
-
-                goto got_next_outer_node;
             }
         }
-
-        node = node->GetNext();
-        got_next_outer_node: continue;
+        node = next;
     }
 
     return true;
@@ -149,20 +144,15 @@ bool ODSelect::DeleteSelectablePathSegment( ODPath *pr, int iUserData )
 
     while( node ) {
         pFindSel = node->GetData();
+        wxSelectableItemListNode *next = node->GetNext();
         if( pFindSel->m_seltype == SELTYPE_PIL ) {
 
             if( (ODPath *) pFindSel->m_pData3 == pr && pFindSel->GetUserData() == iUserData) {
                 delete pFindSel;
                 pSelectList->DeleteNode( node );   //delete node;
-
-                node = pSelectList->GetFirst();     // reset the top node
-
-                goto got_next_outer_node;
             }
         }
-
-        node = node->GetNext();
-        got_next_outer_node: continue;
+        node = next;
     }
 
     return true;
@@ -178,6 +168,7 @@ bool ODSelect::DeleteAllSelectableODPoints( ODPath *pr )
 
     while( node ) {
         pFindSel = node->GetData();
+        wxSelectableItemListNode *next = node->GetNext();
         if( pFindSel->m_seltype == SELTYPE_ODPOINT ) {
             ODPoint *ps = (ODPoint *) pFindSel->m_pData1;
 
@@ -190,17 +181,13 @@ bool ODSelect::DeleteAllSelectableODPoints( ODPath *pr )
                     delete pFindSel;
                     pSelectList->DeleteNode( node );   //delete node;
                     prp->SetSelectNode( NULL );
-                    
-                    node = pSelectList->GetFirst();
-
                     goto got_next_outer_node;
                 }
                 pnode = pnode->GetNext();
             }
         }
-
-        node = node->GetNext();
-got_next_outer_node: continue;
+got_next_outer_node:
+        node = next;
     }
     return true;
 }
@@ -347,6 +334,7 @@ bool ODSelect::DeleteAllSelectableTypePoints( int SeltypeToDelete )
 
     while( node ) {
         pFindSel = node->GetData();
+        wxSelectableItemListNode *next = node->GetNext();
         if( pFindSel->m_seltype == SeltypeToDelete ) {
             delete node;
             
@@ -355,13 +343,9 @@ bool ODSelect::DeleteAllSelectableTypePoints( int SeltypeToDelete )
                 prp->SetSelectNode( NULL );
             }
             delete pFindSel;
-            
-            node = pSelectList->GetFirst();
-            goto got_next_node;
         }
 
-        node = node->GetNext();
-        got_next_node: continue;
+        node = next;
     }
     return true;
 }


### PR DESCRIPTION
Hi,
small speedup.

Currently i'm creation big layers/odpoints, there's a couple of gpx sample at:
http://195.154.231.142/IFREMER/ 
And it's brutal on ocpn draw .

I've something for replacing ODPointIsInPathList with the temporary hash but OpenGL Overlay rendering is the bottleneck when saving a big layer.
ODPointExists is next.

May be at some point using slqlite would make sense (it's not only in draw_pi but there's a lot of wheel re-inventing going on).

BTW I'm looking for a function which can simplify a  polygon but  all functions I've found generate new polygons which don't always fully contain (/Circumscribed?) their source polygon ie new union old is not equal to new.

 When you wrote draw_pi did you see such a beast?

Regards
Didier