### PR TITLE
Save selected path only once in boundary list

### DIFF
--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -1999,8 +1999,16 @@ bool ocpn_draw_pi::MouseEventHook( wxMouseEvent &event )
                     if(m_pSelectedPath->m_sTypeString == wxT("Boundary")) {
                         m_pSelectedBoundary = (Boundary *)m_pSelectedPath;
                         if( event.ControlDown() ) {
-                            m_pBoundaryList.push_back( m_pSelectedBoundary );
-                            m_pSelectedBoundary->m_bPathPropertiesBlink = true;
+                            std::list<Boundary *>::iterator it = m_pBoundaryList.begin();
+                            while( it != m_pBoundaryList.end() ) {
+                                if ( *it == m_pSelectedBoundary)
+                                    break;
+                                ++it;
+                            }
+                            if ( it == m_pBoundaryList.end() ) {
+                                m_pBoundaryList.push_back( m_pSelectedBoundary );
+                                m_pSelectedBoundary->m_bPathPropertiesBlink = true;
+                            }
                         }
                     }
                     else if(m_pSelectedPath->m_sTypeString == wxT("EBL"))


### PR DESCRIPTION
Hi
When selecting multiple boundary path with control click you can select the same more than once and bad things happen, double free , in  ODEventHandler::DeletePaths.
Doesn't solve all my core dump though.

Regards
Didier