### PR TITLE
Fix layer and speedup

### DIFF
--- a/src/BoundaryMan.cpp
+++ b/src/BoundaryMan.cpp
@@ -446,6 +446,8 @@ wxString BoundaryMan::FindLineCrossingBoundary( double StartLon, double StartLat
     ODPoint *popSecond;
     wxString l_GUID = wxEmptyString;
     bool l_bCrosses;
+    LLBBox RBBox;
+    RBBox.SetFromSegment(StartLat, StartLon, EndLat, EndLon);
 
     std::list<BOUNDARYCROSSING> BoundaryCrossingList;
     
@@ -483,7 +485,7 @@ wxString BoundaryMan::FindLineCrossingBoundary( double StartLon, double StartLat
             }
         }
         
-        if(!l_bNext) {
+        if(!l_bNext && !RBBox.IntersectOut(pboundary->GetBBox())) {
             wxODPointListNode *OCPNpoint_node = ( pboundary->m_pODPointList )->GetFirst();
             wxODPointListNode *OCPNpoint_next_node = OCPNpoint_node->GetNext();
 

--- a/src/PointMan.cpp
+++ b/src/PointMan.cpp
@@ -868,19 +868,22 @@ wxString PointMan::FindLineCrossingBoundary( double StartLon, double StartLat, d
     // search boundary point
     wxODPointListNode *node = GetODPointList()->GetFirst();
     while( node ) {
-        BoundaryPoint *op = dynamic_cast<BoundaryPoint *>(node->GetData());
-        if( op && op->IsListed() ) {
-            if( op->m_bIsInPath ) {
-                if( !op->m_bKeepXPath ) {
-                    node = node->GetNext();
-                    continue;
-                }
+        ODPoint *od = static_cast<ODPoint *>(node->GetData());
+        if( od->IsListed() ) {
+            if( od->m_bIsInPath && !od->m_bKeepXPath ) {
+                node = node->GetNext();
+                continue;
             }
             // if there's no ring there's nothing to do
-            if (!op->GetShowODPointRangeRings() || 
-                op->GetODPointRangeRingsNumber() == 0 ||
-                op->GetODPointRangeRingsStep() == 0.f)
+            if (!od->GetShowODPointRangeRings() || 
+                od->GetODPointRangeRingsNumber() == 0 ||
+                od->GetODPointRangeRingsStep() == 0.f)
             {
+                node = node->GetNext();
+                continue;
+            }
+            BoundaryPoint *op = dynamic_cast<BoundaryPoint *>(node->GetData());
+            if (!op) {
                 node = node->GetNext();
                 continue;
             }

--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -2582,11 +2582,11 @@ void ocpn_draw_pi::FindSelectedObject()
             if( ( NULL == pFirstVizPoint ) && bop_viz ) pFirstVizPoint = pop;
             
             // Use path array to choose the appropriate path
-            // Give preference to any active path, otherwise select the first visible path in the array for this point
+            // Give preference to any visible active path, otherwise select the first visible path in the array for this point
             if( ppath_array ) {
                 for( unsigned int ip = 0; ip < ppath_array->GetCount(); ip++ ) {
                     ODPath *pp = (ODPath *) ppath_array->Item( ip );
-                    if( pp->m_bPathIsActive ) {
+                    if( pp->m_bPathIsActive && pp->IsVisible() ) {
                         pSelectedActivePath = pp;
                         pFoundActiveODPoint = pop;
                         break;

--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -1991,7 +1991,7 @@ bool ocpn_draw_pi::MouseEventHook( wxMouseEvent &event )
             FindSelectedObject();
 
             if( 0 != m_seltype ) {
-                if(m_pSelectedPath) {
+                if(m_pSelectedPath && !m_pSelectedPath->m_bIsInLayer) {
                     m_pSelectedBoundary = NULL;
                     m_pSelectedEBL = NULL;
                     m_pSelectedDR = NULL;
@@ -2046,7 +2046,7 @@ bool ocpn_draw_pi::MouseEventHook( wxMouseEvent &event )
                         m_PathMove_cursor_start_lat = m_cursor_lat;
                         m_PathMove_cursor_start_lon = m_cursor_lon;
                     }
-                } else if(m_pFoundODPoint) {
+                } else if(m_pFoundODPoint && !m_pFoundODPoint->m_bIsInLayer) {
                     m_iEditMode = ID_ODPOINT_MENU_MOVE;
                     m_pCurrentCursor = m_pCursorCross;
                     m_bODPointEditing = true;


### PR DESCRIPTION
Hi,
- speedup FindLineCrossingBoundary, still too slow for boundary points not in a path.

- if a path is not visible don't let its points selectable.

- When a path is in a layer you can't edit/move it with the popup menu but you could by dragging mouse.

Regards
Didier