### PR TITLE
boundary must update ODselect when moved

### DIFF
--- a/src/ocpn_draw_pi.cpp
+++ b/src/ocpn_draw_pi.cpp
@@ -2125,11 +2125,12 @@ bool ocpn_draw_pi::MouseEventHook( wxMouseEvent &event )
                 }
                 if(m_pSelectedPath->m_sTypeString == wxT("Guard Zone")) {
                     m_pSelectedGZ->UpdateGZSelectablePath();
-                } else if(m_pSelectedPath->m_sTypeString == wxT("Boundary")) {
-                    m_pSelectedPath->m_bPathPropertiesBlink = false;
                 } else if (m_pSelectedPIL) {
                     m_pSelectedPIL->UpdatePIL();
                 } else {
+                    if(m_pSelectedPath->m_sTypeString == wxT("Boundary")) {
+                       m_pSelectedPath->m_bPathPropertiesBlink = false;
+                    }
                     g_pODSelect->DeleteAllSelectablePathSegments( m_pSelectedPath );
                     g_pODSelect->DeleteAllSelectableODPoints( m_pSelectedPath );
                     g_pODSelect->AddAllSelectablePathSegments( m_pSelectedPath );


### PR DESCRIPTION
Hi,

there's a regression with 25511d:   Make boundaries blink when popup menu displays to highlight...

Paths moved with the mouse don't update ODSelect anymore.

Symptom: can't select a path at its new position after moving it but still selectable at the old one.

Regards
Didier