### PR TITLE
DeleteSelectablePoint point is freed delete all refefences to it

### DIFF
--- a/src/ODSelect.cpp
+++ b/src/ODSelect.cpp
@@ -284,6 +284,7 @@ bool ODSelect::DeleteAllPoints( void )
 bool ODSelect::DeleteSelectablePoint( void *pdata, int SeltypeToDelete )
 {
     SelectItem *pFindSel;
+    bool found = false;
 
     if( NULL != pdata ) {
 //    Iterate on the list
@@ -302,13 +303,13 @@ bool ODSelect::DeleteSelectablePoint( void *pdata, int SeltypeToDelete )
                         prp->SetSelectNode( NULL );
                     }
                     
-                    return true;
+                    found = true;
                 }
             }
             node = node->GetNext();
         }
     }
-    return false;
+    return found;
 }
 
 bool ODSelect::DeleteAllSelectableTypePoints( int SeltypeToDelete )


### PR DESCRIPTION
Hi,
More a bug or a misfeature elsewhere but the first path's point is added twice in ODSelect list. On delete only one was removed and the now invalid reference could be accessed later.

This patch remove all instances of deleted point in list.

Regards
Didier
