### PR TITLE
use the right unit when testing if a position is inside a boundary point rings

### DIFF
--- a/src/BoundaryMan.cpp
+++ b/src/BoundaryMan.cpp
@@ -309,7 +309,13 @@ wxString BoundaryMan::FindPointInBoundaryPoint( double lat, double lon, int type
             if(l_pBoundaryPoint->m_bShowODPointRangeRings && l_pBoundaryPoint->m_iODPointRangeRingsNumber > 0 && !l_bNext) {
                 double l_dRangeRingSize = l_pBoundaryPoint->m_iODPointRangeRingsNumber * l_pBoundaryPoint->m_fODPointRangeRingsStep;
                 double brg;
-                double l_dPointDistance;
+                double factor = 1.00;
+                if( l_pBoundaryPoint->m_iODPointRangeRingsStepUnits == 1 )          // convert kilometer to nautical miles
+                    factor = 1 / 1.852;
+
+                l_dRangeRingSize = factor * l_dRangeRingSize;
+                double l_dPointDistance; // l_dPointDistance is in nautical mile
+
                 DistanceBearingMercator_Plugin( l_pBoundaryPoint->m_lat, l_pBoundaryPoint->m_lon, lat, lon, &brg, &l_dPointDistance );
                 //l_dPointDistance = sqrt(((pboundarypoint->m_lat - lat) * (pboundarypoint->m_lat - lat)) + ((pboundarypoint->m_lon - lon) * (pboundarypoint->m_lon - lon)));
                 if( l_dRangeRingSize > l_dPointDistance ) {

--- a/src/BoundaryPoint.cpp
+++ b/src/BoundaryPoint.cpp
@@ -78,7 +78,7 @@ void BoundaryPoint::Draw(ODDC& dc, wxPoint* rpn )
     GetCanvasPixLL( &g_VP, &r,  m_lat, m_lon);
     
     double factor = 1.00;
-    if( m_iODPointRangeRingsStepUnits == 1 )          // nautical miles
+    if( m_iODPointRangeRingsStepUnits == 1 )          // convert to nautical miles
         factor = 1 / 1.852;
     
     factor *= m_fODPointRangeRingsStep;
@@ -123,7 +123,7 @@ void BoundaryPoint::DrawGL(PlugIn_ViewPort& pivp)
     GetCanvasPixLL( &g_VP, &r,  m_lat, m_lon);
     
     double factor = 1.00;
-    if( m_iODPointRangeRingsStepUnits == 1 )          // nautical miles
+    if( m_iODPointRangeRingsStepUnits == 1 )          // convert to nautical miles
         factor = 1 / 1.852;
     
     factor *= m_fODPointRangeRingsStep;

--- a/src/PointMan.cpp
+++ b/src/PointMan.cpp
@@ -825,7 +825,7 @@ bool PointMan::DistancePointLine( double pLon, double pLat, double StartLon, dou
    double ex, ey;
    double px, py;
    double r = Distance;
-   double radius = 6371007.2;
+   double radius = 6371007.2; // in meters
 
    sx = radius *cos(deg2rad(pLat)) * deg2rad(StartLon);
    sy = radius *deg2rad(StartLat);
@@ -912,7 +912,9 @@ BoundaryPoint *PointMan::FindLineCrossingBoundaryPtr( double StartLon, double St
                     break;
             }
             if (!l_bNext) {
+               // 0 nautical miles 1 kilometer
                double f = (op->m_iODPointRangeRingsStepUnits == 1)?1000.0:1852.31;
+               // in meters
                double dst = op->GetODPointRangeRingsNumber() * op->GetODPointRangeRingsStep() * f;
                if (DistancePointLine( op->m_lon, op->m_lat, StartLon, StartLat, EndLon, EndLat, dst )) {
                   return op;


### PR DESCRIPTION
Hi,

There's a missing conversion if boundary point ring is in kilometer.

Regards
Didier 