### PR TITLE
Update OSX travis uploader

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ script:
        cmake -DCMAKE_BUILD_TYPE=Release ../;
        make -sj2;
        sudo make  package;
+       ls -l;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
     then
@@ -56,7 +57,7 @@ git:
 
 before_install:
       - if [ "$CXX" = "g++" ]; then export CXX="g++-6" CC="gcc-6"; fi
-      - '[ "$TRAVIS_SECURE_ENV_VARS" == "false" ] || openssl aes-256-cbc -K $encrypted_d0e843cd38d7_key -iv $encrypted_d0e843cd38d7_iv -in .dropbox_uploader.enc -out ~/.dropbox_uploader -d'
+      - if [ "${#OAUTH_ACCESS_TOKEN}" != 0 ]; then (echo OAUTH_ACCESS_TOKEN=${OAUTH_ACCESS_TOKEN} > ~/.dropbox_uploader); fi
 
 addons:
   apt:
@@ -71,15 +72,20 @@ addons:
 deploy:
 - provider: script
   file: $TRAVIS_BUILD_DIR/build/*.{deb,rpm,dmg,pkg,txz,pkg.tar.xz}
-  script: if [ -f ~/.dropbox_uploader ];
+  script: if [ -f ~/.dropbox_uploader ] ;
       then
-        if [ "$TRAVIS_OS_NAME" == "osx" ];
+        echo "OSX";
+        if [ "$TRAVIS_OS_NAME" = "osx" ] ;
         then
+            echo "upload pkg";
             bash ../dropbox_uploader.sh upload $TRAVIS_BUILD_DIR/build/*.pkg / ;
         fi;
-        if [ "$TRAVIS_OS_NAME" == "linux" ];
+        echo "Linux";
+        if [ "$TRAVIS_OS_NAME" = "linux" ] ;
         then
+            echo "upload rpm";
             bash ../dropbox_uploader.sh upload $TRAVIS_BUILD_DIR/build/*.rpm /;
+            echo "upload deb";
             bash ../dropbox_uploader.sh upload $TRAVIS_BUILD_DIR/build/*.deb /;
         fi;
       fi
@@ -92,4 +98,5 @@ deploy:
       # and only when API token is set
       # condition: "${#GitHub_auth_token} != 0 && $BUILD_TYPE = Release"
       #condition: "${#GitHub_auth_token} != 0" 
+      condition: "${#OAUTH_ACCESS_TOKEN} != 0"
 


### PR DESCRIPTION
Hi
AFAIK the less intrusive way to do it:

add an environment variable rather than using an encrypted file stored in github:
OAUTH_ACCESS_TOKEN
in travis ocpn_draw_pi project setting.

there's a sed error but it upload.


