### PR TITLE
make travis fail on error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,18 +36,13 @@ script:
   - mkdir build && cd build
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]];
     then
-       cmake -DCMAKE_BUILD_TYPE=Release ../;
-       make -sj2;
-       sudo make  package;
-       ls -l;
+       cmake -DCMAKE_BUILD_TYPE=Release ../ && make -sj2 && sudo make package;
     fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]];
     then
-        cmake -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx312_opencpn50_macos109/bin/wx-config -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx312_opencpn50_macos109" -DCMAKE_INSTALL_PREFIX=/tmp/opencpn -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 ..;
-        make -sj2;
-        make create-pkg;
-        ls -l;
+        cmake -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx312_opencpn50_macos109/bin/wx-config -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx312_opencpn50_macos109" -DCMAKE_INSTALL_PREFIX=/tmp/opencpn -DCMAKE_OSX_DEPLOYMENT_TARGET=10.9 .. && make -sj2 && make create-pkg;
      fi
+  - ls -l;
 
 notifications:
     email: false


### PR DESCRIPTION
Hi
Commands after the same - are run in the same script and travis wasn't failing on cmake or make error. It was using the last command return code, ie ls -l

Use && an move ls -l to a different script for catching cmake and make errors.

Regards
Didier