### PR TITLE
Update antora.yml  title to match "ocpn_draw"

### DIFF
--- a/manual/antora.yml
+++ b/manual/antora.yml
@@ -1,3 +1,3 @@
-name: odraw
+name: ocpn_draw
 title: Ocpn Draw
 version: '0.1'


### PR DESCRIPTION
earlier mistake. Sorry.   Affects links in the manual.  Everyone expects to use ocpn_draw