### PR TITLE
Avoid crashes related to non-GL mode on macOS

### DIFF
--- a/src/ODRolloverWin.cpp
+++ b/src/ODRolloverWin.cpp
@@ -66,7 +66,11 @@ ODRolloverWin::~ODRolloverWin()
 {
     m_timer_timeout.Stop();
     delete m_pbm;
-    glDeleteTextures(1, &m_texture);
+#ifdef ocpnUSE_GL
+    if (g_bOpenGL) {
+        glDeleteTextures(1, &m_texture);
+    }
+#endif
 }
 void ODRolloverWin::OnTimer( wxTimerEvent& event )
 {


### PR DESCRIPTION
On macOS, any OpenGL call made without the GL subsystem properly initialized leads to crash.
Part of the problem is fixed in `opencpn-libs`, hence the update.